### PR TITLE
Add highlighting of single-quoted strings

### DIFF
--- a/src/highlighter.cpp
+++ b/src/highlighter.cpp
@@ -37,7 +37,7 @@ Highlighter::Highlighter(QTextDocument *parent)
     quotationFormat.setFontWeight(QFont::Bold);
     const QList<QString> stringPatterns =
     {
-        QStringLiteral("\"[^\"]*\"")
+        QStringLiteral("[\"\'][^\"\']*[\"|\']")
     };
     for (const QString &pattern : stringPatterns)
     {


### PR DESCRIPTION
Kind of funny, I didn't think about it before I implemented #13 but it could have been a two birds one stone kind of solution. This fixes #2 
You can capture

```lua
"word" .. "word"
```

and

```lua
'word' ... 'word'
```

with one regex very simply `/[\"\'][^\"\']*[\"|\']/`